### PR TITLE
Update weekly type

### DIFF
--- a/lib/ice_cube/validations/weekly_interval.rb
+++ b/lib/ice_cube/validations/weekly_interval.rb
@@ -26,7 +26,7 @@ module IceCube
       end
 
       def type
-        :day
+        :week
       end
 
       def dst_adjust?


### PR DESCRIPTION
The type should be `week` for `weekly_interval.rb`. Double checked with other files (yearly, monthly, daily) to make sure that this type is expected.